### PR TITLE
Support for Python 3 and Installation with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 dist/
 build/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
 
 
 
-### (:pushpin:) Installation:
+### [:pushpin:] Installation:
 
 1. Install required dependencies:
    - `pip install -r requirements.txt`
@@ -21,7 +21,7 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
 
 
 
-### (:gift_heart:) Credits
+### [:gift_heart:] Credits:
 
 [DateTime Library]
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Robot Framework DateTimeTZ library provides functionality for manipulating date and time in different locales and time zones. More information about this library can be found in the [Keyword Documentation].
 
 
-
-### Installation :pushpin:
+:pushpin:
+### Installation:
 
 1. Install required dependencies:
    - `pip install -r requirements.txt`
@@ -20,8 +20,8 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
    - `python setup.py install`
 
 
-
-### Credits :gift_heart:
+:gift_heart:
+### Credits
 
 [DateTime Library]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DateTimeTZ Library for [Robot Framework] :robot:
+# DateTimeTZ Library for [Robot Framework] :robot: with :heart:
 
 Introduction:
 -------------
@@ -25,7 +25,6 @@ Credits:
 -------
 
 [DateTime Library]
-For [Robot Framework] with :heart:
 
 [Keyword Documentation]: https://testautomation.github.io/DateTimeTZ/doc/DateTimeTZ.html
 [Robot Framework]: https://github.com/robotframework/robotframework/blob/master/INSTALL.rst

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DateTime library for Robot Framework
+# DateTimeTZ Library for [Robot Framework] :robot:
 
 Introduction:
 -------------
@@ -7,14 +7,26 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
 
 Installation:
 -------------
-> NOTE: works with Python 2.7  (support for Python 3 is in progress)
 
-1. Make sure you have [Robot Framework] installed.
-2. Install required dependencies:
+1. Install required dependencies:
  - `pip install -r requirements.txt`
-3. Git clone this repository
-4. Go into repository's root folder and install library form source
+
+2. Install DateTimeTZ library with pip
+ - `pip install robotframework-datetime-tz`
+
+3. (*optionally*) Install DateTimeTZ library from source
+ - Git clone this repository
+ - Go into repository's root folder and install library form source
    using: `python setup.py install`
+
+
+
+Credits:
+-------
+
+[DateTime Library]
+For [Robot Framework] with :heart:
 
 [Keyword Documentation]: https://testautomation.github.io/DateTimeTZ/doc/DateTimeTZ.html
 [Robot Framework]: https://github.com/robotframework/robotframework/blob/master/INSTALL.rst
+[DateTime Library]: https://github.com/rmerkushin/DateTime

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
 
 
 
-### :pushpin: Installation
+### Installation :pushpin:
 
 1. Install required dependencies:
    - `pip install -r requirements.txt`
@@ -21,7 +21,7 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
 
 
 
-### :gift_heart: Credits
+### Credits :gift_heart:
 
 [DateTime Library]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DateTimeTZ Library for [Robot Framework] :robot: with :heart:
 
-Introduction:
--------------
+### Introduction:
 
 Robot Framework DateTimeTZ library provides functionality for manipulating date and time in different locales and time zones. More information about this library can be found in the [Keyword Documentation].
 
@@ -22,7 +21,7 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
 
 
 
-## :gift_heart: Credits
+### :gift_heart: Credits
 
 [DateTime Library]
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# DateTimeTZ Library for [Robot Framework] :robot:
+# DateTimeTZ Library for [Robot Framework] with :heart:
 
 Introduction:
 -------------
 
-Robot Framework DateTimeTZ library provides functionality for manipulating date and time in different locales and time zones. More information about this library can be found in the [Keyword Documentation].
+:robot: Robot Framework DateTimeTZ library provides functionality for manipulating date and time in different locales and time zones. More information about this library can be found in the [Keyword Documentation].
 
 Installation:
 -------------

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Robot Framework DateTimeTZ library provides functionality for manipulating date and time in different locales and time zones. More information about this library can be found in the [Keyword Documentation].
 
 
-:pushpin:
-### Installation:
+
+### (:pushpin:) Installation:
 
 1. Install required dependencies:
    - `pip install -r requirements.txt`
@@ -20,8 +20,8 @@ Robot Framework DateTimeTZ library provides functionality for manipulating date 
    - `python setup.py install`
 
 
-:gift_heart:
-### Credits
+
+### (:gift_heart:) Credits
 
 [DateTime Library]
 

--- a/README.md
+++ b/README.md
@@ -5,24 +5,24 @@ Introduction:
 
 Robot Framework DateTimeTZ library provides functionality for manipulating date and time in different locales and time zones. More information about this library can be found in the [Keyword Documentation].
 
-Installation:
--------------
+
+
+### :pushpin: Installation
 
 1. Install required dependencies:
- - `pip install -r requirements.txt`
+   - `pip install -r requirements.txt`
 
 2. Install DateTimeTZ library with pip
- - `pip install robotframework-datetime-tz`
+   - `pip install robotframework-datetime-tz`
 
 3. (*optionally*) Install DateTimeTZ library from source
- - Git clone this repository
- - Go into repository's root folder and install library form source
-   using: `python setup.py install`
+   - Git clone this repository
+   - Go into repository's root folder and install library form source using:
+   - `python setup.py install`
 
 
 
-Credits:
--------
+## :gift_heart: Credits
 
 [DateTime Library]
 

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,18 @@ from setuptools import find_packages, setup
 CURDIR = dirname(abspath(__file__))
 
 classifiers = """
-Development Status :: 4 - Beta
+Development Status :: 2 - Pre-Alpha
 License :: OSI Approved :: Apache Software License
 Operating System :: POSIX
+Operating System :: OS Independent
 Programming Language :: Python
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.6
 Topic :: Software Development :: Testing
+Topic :: Software Development :: Quality Assurance
 Framework :: Robot Framework
 Framework :: Robot Framework :: Library
+Intended Audience :: Developers
 """.strip().splitlines()
 
 
@@ -44,7 +47,7 @@ setup(
     author_email     = "tset.no@gmail.com",
     url              = "https://github.com/testautomation/DateTimeTZ",
     license          = "Apache License 2.0",
-    keywords         = "robotframework test library date time locales time zones",
+    keywords         = "robotframework test automation rpa library date time locales time-zones",
     classifiers      = classifiers,
     install_requires = requirements,
     zip_safe         = False,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ License :: OSI Approved :: Apache Software License
 Operating System :: POSIX
 Programming Language :: Python
 Programming Language :: Python :: 2.7
-Topic :: Software Development :: Testing :: Test Automation
+Programming Language :: Python :: 3.6
+Topic :: Software Development :: Testing
 Framework :: Robot Framework
 Framework :: Robot Framework :: Library
 """.strip().splitlines()
@@ -38,6 +39,7 @@ setup(
     version          = version,
     description      = "Robot Framework library for date/time with locales and time zones",
     long_description = readme,
+    long_description_content_type="text/markdown",
     author           = "Tset Noitamotua",
     author_email     = "tset.no@gmail.com",
     url              = "https://github.com/testautomation/DateTimeTZ",

--- a/src/DateTimeTZ/version.py
+++ b/src/DateTimeTZ/version.py
@@ -14,4 +14,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/src/DateTimeTZ/version.py
+++ b/src/DateTimeTZ/version.py
@@ -14,4 +14,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'


### PR DESCRIPTION
- DateTimeTZ now works with Python 2 and 3 (tested on 2.7.5, 3.6.5)
- Library can be installed with pip and from source